### PR TITLE
Replaced unsecured links by https

### DIFF
--- a/pages/home.htm
+++ b/pages/home.htm
@@ -83,5 +83,3 @@ layout = "default"
     </div>
 
 </div>
-
-<br />

--- a/pages/home.htm
+++ b/pages/home.htm
@@ -83,3 +83,5 @@ layout = "default"
     </div>
 
 </div>
+
+<br />

--- a/pages/home.htm
+++ b/pages/home.htm
@@ -33,7 +33,7 @@ layout = "default"
             </div>
             <div class="col-sm-7 col-sm-offset-1 player-wrapper">
                 <div class="player">
-                    <iframe src="http://player.vimeo.com/video/29568236?color=3498db" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+                    <iframe src="https://player.vimeo.com/video/29568236?color=3498db" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
                 </div>
             </div>
         </div>

--- a/pages/ui-elements.htm
+++ b/pages/ui-elements.htm
@@ -409,8 +409,8 @@ layout = "default"
 	
 	    <div class="col-xs-8">
 	        <video class="video-js" preload="auto" poster="{{ 'assets/images/ui-elements/video/poster.jpg'|theme }}" data-setup="{}">
-	            <source src="http://iurevych.github.com/Flat-UI-videos/big_buck_bunny.mp4" type="video/mp4">
-	            <source src="http://iurevych.github.com/Flat-UI-videos/big_buck_bunny.webm" type="video/webm">
+	            <source src="https://iurevych.github.com/Flat-UI-videos/big_buck_bunny.mp4" type="video/mp4">
+	            <source src="https://iurevych.github.com/Flat-UI-videos/big_buck_bunny.webm" type="video/webm">
 	        </video>
 	    </div> <!-- /video -->
 	</div>


### PR DESCRIPTION
Firefox isn't opening some unsecured contents in pages "home" and "ui-elements" when website is hosted on secured connection. 

Issues has been solved by modifying "http" by "https".